### PR TITLE
Add navigation links to feature items on the homepage

### DIFF
--- a/src/components/HomepageFeatures/index.tsx
+++ b/src/components/HomepageFeatures/index.tsx
@@ -1,8 +1,10 @@
+import Link from "@docusaurus/Link";
 import MountainSvg from "@site/static/img/undraw_docusaurus_mountain.svg";
 import ReactSvg from "@site/static/img/undraw_docusaurus_react.svg";
 import TreeSvg from "@site/static/img/undraw_docusaurus_tree.svg";
 import Heading from "@theme/Heading";
 import clsx from "clsx";
+import { type ComponentProps } from "react";
 
 import styles from "./styles.module.css";
 
@@ -10,6 +12,7 @@ interface FeatureItem {
   title: string;
   Svg: React.ComponentType<React.ComponentProps<"svg">>;
   description: React.ReactNode;
+  to?: ComponentProps<typeof Link>["to"];
 }
 
 const FeatureList: FeatureItem[] = [
@@ -22,6 +25,7 @@ const FeatureList: FeatureItem[] = [
         and expertise for research.
       </>
     ),
+    to: "/docs/hpc/getting_started/intro/",
   },
   {
     title: "High Speed Research Network",
@@ -33,6 +37,7 @@ const FeatureList: FeatureItem[] = [
         sciences.
       </>
     ),
+    to: "/docs/hsrn/intro/",
   },
   {
     title: "Pythia",
@@ -44,6 +49,7 @@ const FeatureList: FeatureItem[] = [
         LLMs and an on-prem vector database.
       </>
     ),
+    to: "/docs/genai/getting_started/intro/",
   },
   {
     title: "RTC",
@@ -55,6 +61,7 @@ const FeatureList: FeatureItem[] = [
         Google Cloud Platform.
       </>
     ),
+    to: "/docs/rtc/intro/",
   },
   {
     title: "SRDE",
@@ -66,12 +73,15 @@ const FeatureList: FeatureItem[] = [
         storage and computational resources specifically for sensitive data.
       </>
     ),
+    to: "/docs/srde/getting_started/intro/",
   },
 ];
 
-function Feature({ title, Svg, description }: FeatureItem) {
+function Feature({ title, Svg, description, to }: FeatureItem) {
+  const Wrapper = to ? Link : "div";
+
   return (
-    <div className={clsx("col col--4")}>
+    <Wrapper className={clsx("col col--4", to && styles.featureLink)} to={to}>
       <div className="text--center">
         <Svg className={styles.featureSvg} role="img" />
       </div>
@@ -79,7 +89,7 @@ function Feature({ title, Svg, description }: FeatureItem) {
         <Heading as="h3">{title}</Heading>
         <p>{description}</p>
       </div>
-    </div>
+    </Wrapper>
   );
 }
 

--- a/src/components/HomepageFeatures/styles.module.css
+++ b/src/components/HomepageFeatures/styles.module.css
@@ -9,3 +9,15 @@
   height: 200px;
   width: 200px;
 }
+
+.featureLink {
+  color: inherit;
+  text-decoration: none;
+  border-radius: 1rem;
+}
+
+.featureLink:hover {
+  color: inherit;
+  text-decoration: none;
+  background-color: rgb(0 0 0 / 5%);
+}


### PR DESCRIPTION
This pull request includes changes to the `HomepageFeatures` component to add links to feature items, allowing users to navigate to specific documentation pages.

Changes to add links to feature items:

- [`src/components/HomepageFeatures/index.tsx`](diffhunk://#diff-9cace34abd690449cb771cf041513cd4b624ebd34921f2cf69e23b183bd59877R1-R15): Imported the `Link` component from `@docusaurus/Link` and the `ComponentProps` type from `react`. Updated the `FeatureItem` interface to include an optional `to` property.
- [`src/components/HomepageFeatures/index.tsx`](diffhunk://#diff-9cace34abd690449cb771cf041513cd4b624ebd34921f2cf69e23b183bd59877R28): Added `to` properties with corresponding documentation URLs to feature items in the `FeatureList` array. [[1]](diffhunk://#diff-9cace34abd690449cb771cf041513cd4b624ebd34921f2cf69e23b183bd59877R28) [[2]](diffhunk://#diff-9cace34abd690449cb771cf041513cd4b624ebd34921f2cf69e23b183bd59877R40) [[3]](diffhunk://#diff-9cace34abd690449cb771cf041513cd4b624ebd34921f2cf69e23b183bd59877R52) [[4]](diffhunk://#diff-9cace34abd690449cb771cf041513cd4b624ebd34921f2cf69e23b183bd59877R64) [[5]](diffhunk://#diff-9cace34abd690449cb771cf041513cd4b624ebd34921f2cf69e23b183bd59877R76-R92)
- [`src/components/HomepageFeatures/index.tsx`](diffhunk://#diff-9cace34abd690449cb771cf041513cd4b624ebd34921f2cf69e23b183bd59877R76-R92): Modified the `Feature` component to conditionally render as a `Link` if the `to` property is provided, otherwise render as a `div`.
- [`src/components/HomepageFeatures/styles.module.css`](diffhunk://#diff-974d2f1dcc3826170a5f1aacfbbde839b4928a259eb7b664a4c161e70824b1dcR12-R23): Added CSS styles for the `.featureLink` class to maintain the appearance and add hover effects.
