### PR TITLE
Enhance styling consistency with Docusaurus/Infima CSS variables

### DIFF
--- a/src/components/HomepageFeatures/styles.module.css
+++ b/src/components/HomepageFeatures/styles.module.css
@@ -21,4 +21,6 @@
   color: inherit;
   text-decoration: none;
   background-color: var(--ifm-hover-overlay);
+  transition: background-color var(--ifm-transition-fast)
+    var(--ifm-transition-timing-default);
 }

--- a/src/components/HomepageFeatures/styles.module.css
+++ b/src/components/HomepageFeatures/styles.module.css
@@ -2,7 +2,7 @@
   display: flex;
   align-items: center;
   width: 100%;
-  padding: 2rem 0;
+  padding: calc(var(--ifm-spacing-vertical) * 2) 0;
 }
 
 .featureSvg {
@@ -13,11 +13,11 @@
 .featureLink {
   color: inherit;
   text-decoration: none;
-  border-radius: 1rem;
+  border-radius: var(--ifm-global-radius);
 }
 
 .featureLink:hover {
   color: inherit;
   text-decoration: none;
-  background-color: rgb(0 0 0 / 5%);
+  background-color: var(--ifm-hover-overlay);
 }

--- a/src/components/HomepageFeatures/styles.module.css
+++ b/src/components/HomepageFeatures/styles.module.css
@@ -2,7 +2,8 @@
   display: flex;
   align-items: center;
   width: 100%;
-  padding: calc(var(--ifm-spacing-vertical) * 2) 0;
+  padding: calc(var(--ifm-spacing-vertical) * 2)
+    calc(var(--ifm-spacing-horizontal) * 2);
 }
 
 .featureSvg {

--- a/src/pages/index.module.css
+++ b/src/pages/index.module.css
@@ -5,14 +5,15 @@
 
 .heroBanner {
   position: relative;
-  padding: 4rem 0;
+  padding: calc(var(--ifm-spacing-vertical) * 4) 0;
   overflow: hidden;
   text-align: center;
 }
 
 @media screen and (width <= 996px) {
   .heroBanner {
-    padding: 2rem;
+    padding: calc(var(--ifm-spacing-vertical) * 2)
+      calc(var(--ifm-spacing-horizontal) * 2);
   }
 }
 


### PR DESCRIPTION
This pull request includes several changes to the CSS files to improve the consistency and maintainability of the styling by using CSS variables from Docusaurus/Infima. This pull request is based on `feature/storage-finder`, because #73 introduced changes that sorted CSS property declarations.

Improvements to styling consistency:

* [`src/components/HomepageFeatures/styles.module.css`](diffhunk://#diff-974d2f1dcc3826170a5f1aacfbbde839b4928a259eb7b664a4c161e70824b1dcL5-R6): Updated the padding to use `var(--ifm-spacing-vertical)` and `var(--ifm-spacing-horizontal)` for consistent spacing.
* [`src/components/HomepageFeatures/styles.module.css`](diffhunk://#diff-974d2f1dcc3826170a5f1aacfbbde839b4928a259eb7b664a4c161e70824b1dcL16-R25): Changed the border-radius to use `var(--ifm-global-radius)` for a consistent border radius.
* [`src/components/HomepageFeatures/styles.module.css`](diffhunk://#diff-974d2f1dcc3826170a5f1aacfbbde839b4928a259eb7b664a4c161e70824b1dcL16-R25): Updated the background-color and added a transition effect using `var(--ifm-hover-overlay)`, `var(--ifm-transition-fast)`, and `var(--ifm-transition-timing-default)` for a consistent hover effect.
* [`src/pages/index.module.css`](diffhunk://#diff-d88ca19240bc4f47684fbd8108114ccbab409c5e48f93069f2e6567222b20b92L8-R16): Updated the padding in the `.heroBanner` class to use `var(--ifm-spacing-vertical)` and `var(--ifm-spacing-horizontal)` for consistent spacing.