### PR TITLE
add css style for lucideIcon

### DIFF
--- a/src/css/custom.css
+++ b/src/css/custom.css
@@ -41,3 +41,9 @@ button,
 select {
   font-family: var(--ifm-font-family-base);
 }
+
+.lucide-icon {
+  display: inline-block;
+  margin-right: 0.4em;
+  vertical-align: middle;
+}


### PR DESCRIPTION
Icons are misaligned without it:
![image](https://github.com/user-attachments/assets/76c80f8d-6cd2-4481-9931-711d72bdd9b1)
